### PR TITLE
Remove forge from package declarations

### DIFF
--- a/src/main/java/com/grape/grapes_ss/BeachpartyForge.java
+++ b/src/main/java/com/grape/grapes_ss/BeachpartyForge.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge;
+package com.grape.grapes_ss;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
@@ -19,9 +19,9 @@ import com.grape.grapes_ss.core.block.BeachSunLounger;
 import com.grape.grapes_ss.core.block.BeachTowelBlock;
 import com.grape.grapes_ss.core.registry.CompostablesRegistry;
 import com.grape.grapes_ss.core.registry.ObjectRegistry;
-import com.grape.grapes_ss.forge.client.integration.CuriosWearableTrinket;
-import com.grape.grapes_ss.forge.registry.BeachpartyConfig;
-import com.grape.grapes_ss.forge.registry.BeachpartyVillagers;
+import com.grape.grapes_ss.client.integration.CuriosWearableTrinket;
+import com.grape.grapes_ss.registry.BeachpartyConfig;
+import com.grape.grapes_ss.registry.BeachpartyVillagers;
 import com.grape.grapes_ss.platform.PlatformHelper;
 
 @Mod(Beachparty.MOD_ID)

--- a/src/main/java/com/grape/grapes_ss/client/BeachpartyClientForge.java
+++ b/src/main/java/com/grape/grapes_ss/client/BeachpartyClientForge.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client;
+package com.grape.grapes_ss.client;
 
 import net.minecraft.client.model.BoatModel;
 import net.minecraft.client.model.ChestBoatModel;
@@ -19,8 +19,8 @@ import com.grape.grapes_ss.client.BeachPartyClient;
 import com.grape.grapes_ss.client.model.FloatyBoatModel;
 import com.grape.grapes_ss.core.entity.PalmBoatEntity;
 import com.grape.grapes_ss.core.registry.ObjectRegistry;
-import com.grape.grapes_ss.forge.client.integration.*;
-import com.grape.grapes_ss.forge.client.renderer.player.layers.*;
+import com.grape.grapes_ss.client.integration.*;
+import com.grape.grapes_ss.client.renderer.player.layers.*;
 import top.theillusivec4.curios.api.client.CuriosRendererRegistry;
 
 import java.util.function.Function;

--- a/src/main/java/com/grape/grapes_ss/client/integration/CuriosBeachHatRenderer.java
+++ b/src/main/java/com/grape/grapes_ss/client/integration/CuriosBeachHatRenderer.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.integration;
+package com.grape.grapes_ss.client.integration;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/grape/grapes_ss/client/integration/CuriosBikiniRenderer.java
+++ b/src/main/java/com/grape/grapes_ss/client/integration/CuriosBikiniRenderer.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.integration;
+package com.grape.grapes_ss.client.integration;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/grape/grapes_ss/client/integration/CuriosRubberRingAxolotlRenderer.java
+++ b/src/main/java/com/grape/grapes_ss/client/integration/CuriosRubberRingAxolotlRenderer.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.integration;
+package com.grape.grapes_ss.client.integration;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/grape/grapes_ss/client/integration/CuriosRubberRingPelicanRenderer.java
+++ b/src/main/java/com/grape/grapes_ss/client/integration/CuriosRubberRingPelicanRenderer.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.integration;
+package com.grape.grapes_ss.client.integration;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/grape/grapes_ss/client/integration/CuriosRubberRingRenderer.java
+++ b/src/main/java/com/grape/grapes_ss/client/integration/CuriosRubberRingRenderer.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.integration;
+package com.grape.grapes_ss.client.integration;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/grape/grapes_ss/client/integration/CuriosTrunksRenderer.java
+++ b/src/main/java/com/grape/grapes_ss/client/integration/CuriosTrunksRenderer.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.integration;
+package com.grape.grapes_ss.client.integration;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/grape/grapes_ss/client/integration/CuriosWearableTrinket.java
+++ b/src/main/java/com/grape/grapes_ss/client/integration/CuriosWearableTrinket.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.integration;
+package com.grape.grapes_ss.client.integration;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleOptions;

--- a/src/main/java/com/grape/grapes_ss/client/renderer/player/layers/BeachHatLayer.java
+++ b/src/main/java/com/grape/grapes_ss/client/renderer/player/layers/BeachHatLayer.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.renderer.player.layers;
+package com.grape.grapes_ss.client.renderer.player.layers;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/grape/grapes_ss/client/renderer/player/layers/BikiniLayer.java
+++ b/src/main/java/com/grape/grapes_ss/client/renderer/player/layers/BikiniLayer.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.renderer.player.layers;
+package com.grape.grapes_ss.client.renderer.player.layers;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/grape/grapes_ss/client/renderer/player/layers/TrunksLayer.java
+++ b/src/main/java/com/grape/grapes_ss/client/renderer/player/layers/TrunksLayer.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.client.renderer.player.layers;
+package com.grape.grapes_ss.client.renderer.player.layers;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/grape/grapes_ss/event/ForgeEventHandler.java
+++ b/src/main/java/com/grape/grapes_ss/event/ForgeEventHandler.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.event;
+package com.grape.grapes_ss.event;
 
 import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.npc.VillagerTrades;
@@ -11,8 +11,8 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import com.grape.grapes_ss.Beachparty;
 import com.grape.grapes_ss.core.registry.ObjectRegistry;
-import com.grape.grapes_ss.forge.client.integration.CuriosWearableTrinket;
-import com.grape.grapes_ss.forge.registry.BeachpartyVillagers;
+import com.grape.grapes_ss.client.integration.CuriosWearableTrinket;
+import com.grape.grapes_ss.registry.BeachpartyVillagers;
 
 
 import java.util.List;

--- a/src/main/java/com/grape/grapes_ss/mixin/DyeableArmorMixin.java
+++ b/src/main/java/com/grape/grapes_ss/mixin/DyeableArmorMixin.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.mixin;
+package com.grape.grapes_ss.mixin;
 
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.HumanoidModel;
@@ -12,7 +12,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.extensions.common.IClientItemExtensions;
 import com.grape.grapes_ss.core.item.DyeableBeachpartyArmorItem;
 import com.grape.grapes_ss.core.registry.ArmorRegistry;
-import com.grape.grapes_ss.forge.model.DyedArmorModelWrapper;
+import com.grape.grapes_ss.model.DyedArmorModelWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/com/grape/grapes_ss/mixin/HelmetItemMixin.java
+++ b/src/main/java/com/grape/grapes_ss/mixin/HelmetItemMixin.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.mixin;
+package com.grape.grapes_ss.mixin;
 
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.Model;

--- a/src/main/java/com/grape/grapes_ss/model/DyedArmorModelWrapper.java
+++ b/src/main/java/com/grape/grapes_ss/model/DyedArmorModelWrapper.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.model;
+package com.grape.grapes_ss.model;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;

--- a/src/main/java/com/grape/grapes_ss/platform/PlatformHelper.java
+++ b/src/main/java/com/grape/grapes_ss/platform/PlatformHelper.java
@@ -17,7 +17,7 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import com.grape.grapes_ss.Beachparty;
-import com.grape.grapes_ss.forge.registry.BeachpartyConfig;
+import com.grape.grapes_ss.registry.BeachpartyConfig;
 
 import java.util.List;
 import java.util.function.Supplier;

--- a/src/main/java/com/grape/grapes_ss/registry/BeachpartyConfig.java
+++ b/src/main/java/com/grape/grapes_ss/registry/BeachpartyConfig.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.registry;
+package com.grape.grapes_ss.registry;
 
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.electronwill.nightconfig.core.io.WritingMode;

--- a/src/main/java/com/grape/grapes_ss/registry/BeachpartyVillagers.java
+++ b/src/main/java/com/grape/grapes_ss/registry/BeachpartyVillagers.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.registry;
+package com.grape.grapes_ss.registry;
 
 import com.google.common.collect.ImmutableSet;
 import net.minecraft.sounds.SoundEvents;

--- a/src/main/java/com/grape/grapes_ss/rei/BeachpartyREIClientPluginForge.java
+++ b/src/main/java/com/grape/grapes_ss/rei/BeachpartyREIClientPluginForge.java
@@ -1,4 +1,4 @@
-package com.grape.grapes_ss.forge.rei;
+package com.grape.grapes_ss.rei;
 
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;

--- a/src/main/resources/beachparty.mixins.json
+++ b/src/main/resources/beachparty.mixins.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "package": "com.grape.grapes_ss.forge.mixin",
+  "package": "com.grape.grapes_ss.mixin",
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [


### PR DESCRIPTION
## Summary
- update package declarations to remove `.forge` path segments
- adjust imports and mixin configuration accordingly

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c04022a4083218454be720ad2e3d8